### PR TITLE
Remove unnecessary options

### DIFF
--- a/aliyun-cli/tools/chocolateyinstall.ps1
+++ b/aliyun-cli/tools/chocolateyinstall.ps1
@@ -1,21 +1,15 @@
-﻿
-$ErrorActionPreference = 'Stop';
+﻿$ErrorActionPreference = 'Stop';
+
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $url64      = 'https://aliyuncli.alicdn.com/aliyun-cli-windows-3.0.202-amd64.zip'
 $checksum64 = '996bf2c0ba21ebf711c4bb441a720c347926a75bd6292756fb2af99df56f87a4'
 
 $packageArgs = @{
-  packageName   = $env:ChocolateyPackageName
-  unzipLocation = $toolsDir
-  fileType      = 'ZIP'
-  url64bit      = $url64
-  softwareName  = 'aliyun-cli*'
-
-  checksum64    = $checksum64
-  checksumType64= 'sha256'
-
-  silentArgs    = "/qn /norestart /l*v `"$($env:TEMP)\$($packageName).$($env:chocolateyPackageVersion).MsiInstall.log`""
-  validExitCodes= @(0, 3010, 1641)
+  packageName    = $env:ChocolateyPackageName
+  unzipLocation  = $toolsDir
+  url64bit       = $url64
+  checksum64     = $checksum64
+  checksumType64 = 'sha256'
 }
 
 Install-ChocolateyZipPackage @packageArgs


### PR DESCRIPTION
As per the documentation here:

https://docs.chocolatey.org/en-us/create/functions/install-chocolateyzippackage

There were a number of parameters being used which are not used by the Install-ChocolateyZipPackage function.

This commit addresses that by removing them. Also, a general set of format changes was completed.