### PR TITLE
Fix `ERROR: Parameter cannot be processed because the parameter name 'Path' is ambiguous.`

### DIFF
--- a/gcloudsdk/tools/chocolateyinstall.ps1
+++ b/gcloudsdk/tools/chocolateyinstall.ps1
@@ -31,4 +31,4 @@ Install-ChocolateyZipPackage @packageArgs
 Write-Verbose 'Deleting symlink files that will fail the checksum process'
 Get-ChildItem -Path "$toolsDir" -Recurse -File |  Where-Object { $_.LinkType -ne $null -or $_.Attributes -match "ReparsePoint" } | Remove-Item -Force
 
-Install-ChocolateyPath -Path "$($toolsDir)\google-cloud-sdk\bin"
+Install-ChocolateyPath -pathToInstall "$($toolsDir)\google-cloud-sdk\bin"


### PR DESCRIPTION
I'm trying to automatically install this package as part of a puppet workflow, but ever since [this commit](https://github.com/glucn/chocolatey-packages/commit/5d39423347e868e6c83934dc8920b2fc41406ded) (or any version I tried after `482.0.0`) ends up with the following error (thrown at the end of chocolateyinstall.ps1) for me:

```
ERROR: Parameter cannot be processed because the parameter name 'Path' is ambiguous. Possible matches include: -pathToInstall -pathType.
The install of gcloudsdk was NOT successful.
```

I believe the reason might be that in the linked commit, `-PathType` was removed. In an attempt to fix this myself I just cloned the repo, changed what I believed was the offending parameter to what chocolatey was suggesting, and it worked wonderfully!

However, due to my lack of experience with chocolatey (I just did a very small package myself so just know the very basics), I'm not sure if I might be missing any reasoning here, so feel free to disagree. I mainly just want to spark a discussion around this issue since I really want to upgrade to get the versioned archive change to be able to do pinned installs, since with 482.0.0 I cannot control the gcloud version that ends up getting installed and also I need to keep updating the checksums to match.

Thank you very much for your time, happy to change/test whatever you suggest!